### PR TITLE
remove unknown type for Pfam

### DIFF
--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -14,8 +14,8 @@ _TYPES = {
     "Domain": 'D',
     "Family": 'F',
     "Repeat": 'R',
-    "Coiled-coil": 'U',
-    "Disordered": 'U',
+    "Coiled-coil": 'I',
+    "Disordered": 'O',
     "Motif": 'C'
 }
 


### PR DESCRIPTION
I've also updated the following ORACLE tables:
INSERT INTO INTERPRO.CV_ENTRY_TYPE VALUES ('I', 'Coiled coil', 'Detoning characteristic heptad repeat');
INSERT INTO INTERPRO.CV_ENTRY_TYPE VALUES ('O', 'Disordered', 'Conserved intrasincally disordered regions');
ALTER TABLE INTERPRO.METHOD 
ADD CONSTRAINT CK_METHOD$SIG_TYPE CHECK( (SIG_TYPE IN ('O', 'I') AND DBCODE='H' ) OR (SIG_TYPE NOT IN ('O','I')));
ALTER TABLE INTERPRO.ENTRY
ADD CONSTRAINT CK_ENTRY$ENTRY_TYPE CHECK (ENTRY_TYPE NOT IN ('O', 'I', 'U', 'G'));