### PR TITLE
IBU-10833

### DIFF
--- a/config/members.conf
+++ b/config/members.conf
@@ -42,6 +42,11 @@ seed =
 full = 
 clan = 
 fasta = 
+rp15 =
+rp35 =
+rp55 =
+rp75 = 
+uniprot =
 
 [pfam-n]
 signatures =

--- a/config/members.conf
+++ b/config/members.conf
@@ -38,6 +38,10 @@ triage =
 hmm =
 members =
 signatures =
+seed = 
+full = 
+clan = 
+fasta = 
 
 [pfam-n]
 signatures =

--- a/pyinterprod/cli.py
+++ b/pyinterprod/cli.py
@@ -226,6 +226,14 @@ def run_clan_update():
                              cddid=params["summary"],
                              fam2supfam=params["members"],
                              **kwargs)
+        elif dbname == "pfam":
+            update_hmm_clans(ora_interpro_uri, database,
+                             hmmdb=params["hmm"],
+                             source=params["members"],
+                             pfam_clan_path=["clan"],
+                             pfam_fasta_path=["fasta"],
+                             pfam_full_path=["full"],
+                             **kwargs)
         else:
             update_hmm_clans(ora_interpro_uri, database,
                              hmmdb=params["hmm"],

--- a/pyinterprod/cli.py
+++ b/pyinterprod/cli.py
@@ -883,7 +883,7 @@ def run_uniprot_update():
             requires=["update-ipm-matches"]
         ),
         Task(
-            fn=interpro.match n.update_site_matches,
+            fn=interpro.match.update_site_matches,
             args=(ora_interpro_uri,),
             name="update-sites",
             scheduler=dict(type="lsf", queue=lsf_queue),

--- a/pyinterprod/cli.py
+++ b/pyinterprod/cli.py
@@ -230,9 +230,9 @@ def run_clan_update():
             update_hmm_clans(ora_interpro_uri, database,
                              hmmdb=params["hmm"],
                              source=params["members"],
-                             pfam_clan_path=["clan"],
-                             pfam_fasta_path=["fasta"],
-                             pfam_full_path=["full"],
+                             pfam_clan_path=params["clan"],
+                             pfam_fasta_path=params["fasta"],
+                             pfam_full_path=params["full"],
                              **kwargs)
         else:
             update_hmm_clans(ora_interpro_uri, database,
@@ -456,6 +456,18 @@ def run_member_db_update():
                 requires=ipm_dependencies + ["update-signatures"]
             )
         ]
+
+        for db in member_dbs:
+            if db.identifier == 'H':
+                tasks.append(
+                    Task(
+                        fn=interpro.contrib.pfam.persist_extra_pfam_data,
+                        args=(model_sources[db.identifier], ora_interpro_uri,),
+                        names="persist-pfam",
+                        scheduler=dict(type="lsf", queue=lsf_queue),
+                        requires=ipm_dependencies + ["update-signatures"]
+                    )
+                )
 
     feature_dbs += non_ipm_dbs
     if feature_dbs:
@@ -871,7 +883,7 @@ def run_uniprot_update():
             requires=["update-ipm-matches"]
         ),
         Task(
-            fn=interpro.match.update_site_matches,
+            fn=interpro.match n.update_site_matches,
             args=(ora_interpro_uri,),
             name="update-sites",
             scheduler=dict(type="lsf", queue=lsf_queue),

--- a/pyinterprod/interpro/clan.py
+++ b/pyinterprod/interpro/clan.py
@@ -7,6 +7,7 @@ import subprocess as sp
 import sys
 from concurrent import futures
 from tempfile import mkdtemp, mkstemp
+from typing import Optional
 
 import oracledb
 
@@ -593,10 +594,19 @@ def update_cdd_clans(url: str, database: Database, cddmasters: str,
             raise RuntimeError(f"{errors} error(s)")
 
 
-def update_hmm_clans(url: str, database: Database, hmmdb: str, **kwargs):
+def update_hmm_clans(
+    url: str,
+    database: Database,
+    hmmdb: str,
+    pfam_clan_path: Optional[str] = None,
+    pfam_fasta_path: Optional[str] = None,
+    pfam_full_path: Optional[str] = None,
+    **kwargs
+):
     clan_source = kwargs.get("source")
     threads = kwargs.get("threads")
     tmpdir = kwargs.get("tmpdir")
+
     if tmpdir:
         os.makedirs(tmpdir, exist_ok=True)
 
@@ -615,7 +625,11 @@ def update_hmm_clans(url: str, database: Database, hmmdb: str, **kwargs):
 
         def getsubdir(x): return x[:7]
     elif database.name.lower() == "pfam":
-        clans = contrib.pfam.get_clans(clan_source)
+        clans = contrib.pfam.get_clans(
+            pfam_clan_path,
+            pfam_fasta_path,
+            pfam_full_path,
+        )
 
         def getsubdir(x): return x[:5]
     elif database.name.lower() == "pirsf":

--- a/pyinterprod/interpro/contrib/common.py
+++ b/pyinterprod/interpro/contrib/common.py
@@ -11,7 +11,6 @@ class Method:
     name: str | None = None
     description: str | None = None
     abstract: str | None = None
-    date: datetime | None = None
     references: list[int] = field(default_factory=list)
     model: str | None = None
 

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -12,6 +12,7 @@ from pyinterprod.utils.oracle import drop_table
 from pyinterprod.utils.pg import url2dict
 
 
+_RECORD_BREAK = "//"
 _TYPES = {
     "Domain": 'D',
     "Family": 'F',
@@ -130,7 +131,7 @@ def get_signatures(pfam_path: str, persist_pfam=False) -> list[Method] | dict:
             ) = get_default_values(signatures=True)
 
             for line in fh:
-                if line.strip() == RECORD_BREAK:
+                if line.strip() == _RECORD_BREAK:
                     # create signature record from previous Pfam record
                     formatter = AbstractFormatter(references)
 
@@ -290,7 +291,7 @@ def get_num_full(
 
             for line in fh:
 
-                if line.strip() == RECORD_BREAK:
+                if line.strip() == _RECORD_BREAK:
                     # store the previous record
                     num_fulls[accession] = num_full_count
                     
@@ -362,7 +363,7 @@ def get_clans(
 
             for line in fh:
 
-                if line.strip() == RECORD_BREAK:
+                if line.strip() == _RECORD_BREAK:
                     # store the previous record
                     clan = Clan(
                             accession,

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -569,7 +569,7 @@ def persist_extra_pfam_data(
         drop_table(cur, "INTERPRO.PFAM_AUTHOR", purge=True)
         cur.execute(
             """
-            CREATE TABLE INTERPRO.PFAM_DATA (
+            CREATE TABLE INTERPRO.PFAM_AUTHOR (
                 accession VARCHAR2(25) PRIMARY KEY,
                 author VARCHAR2(225),
                 orcid VARCHAR2(225)

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -141,6 +141,34 @@ def get_signatures(pfam_path: str) -> list[Method], dict:
                         )
                     )
 
+                    entries[accession] = {
+                        "curation": {
+                            "sequence_ontology": sequence_ontology,
+                            "authors": author_info,
+                        },
+                        "hmm": {
+                            "commands": {
+                                "build": build_method,
+                                "search": search_method,
+                            },
+                            "cutoffs": {
+                                "gathering": {
+                                    "sequence": sequence_ga,
+                                    "domain": domain_ga
+                                }
+                            },
+                            "version": version,
+                        },
+                        "wiki": wiki,
+                        "pyinterprod": {
+                            "pfam_id": name,
+                            "description": description,
+                            "long_type": long_type,
+                            "abstract": abstract,
+                            "references": references,
+                        }
+                    }
+
                     # start afresh for the next record/signature
                     (
                         accession,
@@ -177,6 +205,31 @@ def get_signatures(pfam_path: str) -> list[Method], dict:
                 elif line.startswith("#=GF RM"):
                     references[current_ref_pos] = int(line[7:].strip())  # = pmid
 
+
+                elif bool(re.match(r'^#=GF\s+DR', line)):
+                    sequence_ontology = line.split(";")[1].strip()
+
+                elif line.startswith("#=GF AU"):
+                    author_info.append(
+                        (
+                            line[7:].split(";")[0].strip(),  # author
+                            line.split(";")[1].strip(),  # orcidID
+                        )
+                    )
+
+                elif line.startswith("#=GF BM"):
+                    build_method = line[7:].strip()
+
+                elif line.startswith("#=GF SM"):
+                    search_method = line[7:].strip()
+
+                elif line.startswith("#=GF GA"):  # GA = gathering threshold
+                    sequence_ga = line[7:].strip().split(" ")[0].strip()
+                    domain_ga = line[7:].strip().split(" ")[1].replace(";","").strip()
+
+                elif line.startswith("#=GF WK"):
+                    wiki = line[7:].strip().replace(" ", "_")   # wikipedia article
+
     except UnicodeDecodeError:
         pass
 
@@ -187,9 +240,9 @@ def get_signatures(pfam_path: str) -> list[Method], dict:
                 "Not retrieving signature data"
             ), pfam_path
         )
-        return signatures
+        return signatures, entries
 
-    return signatures
+    return signatures, entries
 
 
 def get_fam_seq_counts(

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -631,10 +631,11 @@ def persist_extra_pfam_data(
                     (pfam_acc,) + author_info
                 )
             
-            cur.execute(
-                wiki_query,
-                [pfam_acc, signatures[pfam_acc]["wiki"]]
-            )
+            if signatures[pfam_acc]['wiki']:
+                cur.execute(
+                    wiki_query,
+                    [pfam_acc, signatures[pfam_acc]["wiki"]]
+                )
     
     con.commit()
     con.close()

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -8,7 +8,6 @@ from .common import Clan, Method
 from pyinterprod import logger
 from pyinterprod.utils import Table
 from pyinterprod.utils.oracle import drop_table
-from pyinterprod.utils.pg import url2dict
 
 
 _RECORD_BREAK = "//"

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -615,7 +615,7 @@ def persist_extra_pfam_data(
             cur.execute(
                 pfam_query,
                 [
-                    pfam_acc,
+                    pfam_acc.split(".")[0],
                     signatures[pfam_acc]["curation"]["sequence_ontology"],
                     signatures[pfam_acc]["hmm"]["commands"]["build"],
                     signatures[pfam_acc]["hmm"]["commands"]["search"],
@@ -628,14 +628,13 @@ def persist_extra_pfam_data(
             for author_info in signatures[pfam_acc]["curation"]["authors"]:
                 cur.execute(
                     author_query,
-                    (pfam_acc,) + author_info
+                    (pfam_acc.split(".")[0],) + author_info
                 )
             
-            if signatures[pfam_acc]['wiki']:
-                cur.execute(
-                    wiki_query,
-                    [pfam_acc, signatures[pfam_acc]["wiki"]]
-                )
+            cur.execute(
+                wiki_query,
+                [pfam_acc.split(".")[0], signatures[pfam_acc]["wiki"]]
+            )
     
     con.commit()
     con.close()

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -541,7 +541,7 @@ def persist_extra_pfam_data(
     author_query = """
         INSERT /*+ APPEND */ 
         INTO INTERPRO.PFAM_AUTHOR
-        VALUES (:1, :2, :3)
+        VALUES (:1, :2)
     """
     wiki_query = """
         INSERT /*+ APPEND */ 

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -261,7 +261,7 @@ def get_fam_seq_counts(
     fams = {}
 
     try:
-        with gzip.open(PFAM_FASTA, 'rt') as fh:
+        with gzip.open(pfam_fasta_path, 'rt') as fh:
             for line in fh:
                 if line.startswith(">"):
                     pfamA_acc = line.strip().split(" ")[-1].split(";")[0].split(".")[0]

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -1,3 +1,4 @@
+import gzip
 import re
 
 import MySQLdb
@@ -349,7 +350,7 @@ def get_clans(
         return clans
     logger.info("Completed")
 
-   logger.info("Getting Clans")
+    logger.info("Getting Clans")
     try:
         with gzip.open(pfam_clan_path, 'rt') as fh:
             (

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -237,9 +237,6 @@ def get_signatures(pfam_path: str, persist_pfam=False) -> list[Method] | dict:
                 "Not retrieving signature data"
             ), pfam_path
         )
-        if persist_pfam:
-            return entries
-        return signatures
 
     if persist_pfam:
         return entries

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -401,8 +401,6 @@ def get_clans(
                         try:
                             num_full = num_fulls[pfamA_acc]  # num of seq accessions listed in full alignment (pfam-a.full)
                         except KeyError:
-                            if pfamA_acc in dead_fams:
-                                continue
                                 
                             num_full = 0
                             logger.warning("Could not find num_full for %s in clan %s -> Setting score as '0'", pfamA_acc, accession)

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -351,7 +351,6 @@ def get_clans(
             ), pfam_full_path
         )
         return clans
-    logger.info("Completed")
 
     logger.info("Getting Pfam family seq counts")
     fam_seq_counts = get_fam_seq_counts(pfam_fasta_path)
@@ -363,7 +362,6 @@ def get_clans(
             ), pfam_fasta_path
         )
         return clans
-    logger.info("Completed")
 
     logger.info("Getting Clans")
     try:
@@ -449,8 +447,6 @@ def get_clans(
                 "Not retrieving clan data"
             ), pfam_clan_path
         )
-    
-    logger.info("Completed")
 
     return list(clans.values())
 

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -631,10 +631,11 @@ def persist_extra_pfam_data(
                     (pfam_acc.split(".")[0],) + author_info
                 )
             
-            cur.execute(
-                wiki_query,
-                [pfam_acc.split(".")[0], signatures[pfam_acc]["wiki"]]
-            )
+            if signatures[pfam_acc]["wiki"]:
+                cur.execute(
+                    wiki_query,
+                    [pfam_acc.split(".")[0], signatures[pfam_acc]["wiki"]]
+                )
     
     con.commit()
     con.close()

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -77,6 +77,14 @@ def get_default_values(
     Long type (e.g. Family, Domain, etc.) [str]
     Abstract [empty str that is added]
     References {order added/pos ref [int]: pmid [int]}
+    sequence ontology: None
+    Author info [(author, orcid)]
+    Build method: None
+    Search method: None
+    Sequence gathering threshold: None
+    Domain gather threshold: None
+    Wikipedia article: None
+    Version: None
 
     For clans return:
     Clan accessio number, excluding version num [int]
@@ -85,19 +93,22 @@ def get_default_values(
     List of member accessions [List[str]]
     """
     if signatures:
-        return None, None, None, None, "", {}
+        return None, None, None, None, "", {}, None, [], None, None, None, None, None, None
     if clans:
         return None, None, None, []
 
 
-def get_signatures(pfam_path: str) -> list[Method]:
+def get_signatures(pfam_path: str) -> list[Method], dict:
     """Parse Pfam-A.seed.gz file and extract signatures.
 
     :param pfam_path: str, path to Pfam-A.seed.gz file
     
-    Return list of Method objs
+    Return 
+    * list of Method objs
+    * dict of entries
     """
-    signatures =[]
+    signatures = []
+    entries = {}
 
     try:
         with gzip.open(pfam_path, 'rt') as fh:
@@ -108,6 +119,10 @@ def get_signatures(pfam_path: str) -> list[Method]:
                 long_type,
                 abstract,
                 references,  # {order added/pos ref [int]: pmid [int]}
+                sequence_ontology, author_info,
+                build_method, search_method,
+                sequence_ga, domain_ga,
+                wiki, version,
             ) = get_default_values(signatures=True)
 
             for line in fh:
@@ -134,6 +149,10 @@ def get_signatures(pfam_path: str) -> list[Method]:
                         long_type,
                         abstract,
                         references,  # {order added/pos ref [int]: pmid [int]}
+                        sequence_ontology, author_info,
+                        build_method, search_method,
+                        sequence_ga, domain_ga,
+                        wiki, version,
                     ) = get_default_values(signatures=True)
                 
                 elif line.startswith("#=GF AC"):

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -446,7 +446,7 @@ def get_clans(
             ), pfam_clan_path
         )
 
-    return list(clans.values())
+    return clans
 
 
 def iter_protenn_matches(file: str):

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -1,4 +1,5 @@
 import gzip
+import os
 import re
 
 import MySQLdb
@@ -325,14 +326,27 @@ def get_clans(
     :param pfam_fasta_path: path to Pfam-A.fasta.gz file
     :param pfam_full_path: path to Pfam-A-full.gz alignment file
     """
-    clans =[]
+    clans = []
+
+    clan_file_found, fasta_file_found, full_file_found = True, True, True
+    if os.path.isfile(pfam_clan_path) is False:
+        logger.error("Could not find Pfam-C (clan file) at %s", pfam_clan_path)
+        clan_file_found = False
+    if os.path.isfile(pfam_fasta_path) is False:
+        logger.error("Could not find Pfam-A-fasta file at %s", pfam_fasta_path)
+        fasta_file_found = False
+    if os.path.isfile(pfam_full_path) is False:
+        logger.error("Could not find Pfam-A-full file at %s", pfam_full_path)
+    if any(_ is False for _ in (clan_file_found, fasta_file_found, full_file_found)):
+        logger.error("Check Pfam file paths are correct.\nNot retrieving clan data")
+        return clans
 
     logger.info("Getting num_full values")
     num_fulls = get_num_full(pfam_full_path)
     if num_fulls is None:
         logger.error(
             (
-                "Could not find Pfam-A-full (full alignment file) at %s\n"
+                "Could not retrieve num_full values from Pfam-A-full (full alignment file) at %s\n"
                 "Not retrieving clan data"
             ), pfam_full_path
         )
@@ -344,7 +358,7 @@ def get_clans(
     if fam_seq_counts is None:
         logger.error(
             (
-                "Could not find Pfam FASTA file at %s\n"
+                "Could not parse Pfam FASTA file at %s\n"
                 "Not retrieving clan data"
             ), pfam_fasta_path
         )
@@ -431,7 +445,7 @@ def get_clans(
     except FileNotFoundError:
         logger.error(
             (
-                "Could not find Pfam-C (clan) file at %s\n"
+                "Could not parse Pfam-C (clan) file at %s\n"
                 "Not retrieving clan data"
             ), pfam_clan_path
         )

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -533,6 +533,8 @@ def persist_extra_pfam_data(
         persist_pfam=True,
     )
 
+    logger.info("Persisting data for %s signatures", len(signatures))
+
     pfam_query = """
         INSERT /*+ APPEND */ 
         INTO INTERPRO.PFAM_DATA 

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -541,7 +541,7 @@ def persist_extra_pfam_data(
     author_query = """
         INSERT /*+ APPEND */ 
         INTO INTERPRO.PFAM_AUTHOR
-        VALUES (:1, :2)
+        VALUES (:1, :2, :3)
     """
     wiki_query = """
         INSERT /*+ APPEND */ 
@@ -570,7 +570,7 @@ def persist_extra_pfam_data(
         cur.execute(
             """
             CREATE TABLE INTERPRO.PFAM_AUTHOR (
-                accession VARCHAR2(25) PRIMARY KEY,
+                accession VARCHAR2(25),
                 author VARCHAR2(225),
                 orcid VARCHAR2(225)
             )
@@ -581,7 +581,7 @@ def persist_extra_pfam_data(
         cur.execute(
             """
             CREATE TABLE INTERPRO.PFAM_WIKIPEDIA (
-                accession VARCHAR2(25) PRIMARY KEY,
+                accession VARCHAR2(25),
                 title VARCHAR2(225)
             )
             """
@@ -604,10 +604,10 @@ def persist_extra_pfam_data(
             for author_info in signatures[pfam_acc]["curation"]["authors"]:
                 cur.execute(
                     author_query,
-                    author_info
+                    (pfam_acc,) + author_info
                 )
             
             cur.execute(
                 wiki_query,
-                signatures[pfam_acc]["wiki"]
+                [pfam_acc, signatures[pfam_acc]["wiki"]]
             )

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -636,4 +636,5 @@ def persist_extra_pfam_data(
                 [pfam_acc, signatures[pfam_acc]["wiki"]]
             )
     
+    con.commit()
     con.close()

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -761,7 +761,7 @@ def persist_extra_pfam_data(
                             clan_id,
                             clans[clan_id]['references'][order_added]['pmid'],
                             _check_str_len(clan_id, clans[clan_id]['references'][order_added]['title'], "TITLE", 500),
-                            _check_str_len(clan_id, clans[clan_id]['references'][order_added]['authors'], "AUTHORS", 500),
+                            _check_str_len(clan_id, clans[clan_id]['references'][order_added]['authors'][:-1], "AUTHORS", 500),
                             clans[clan_id]['references'][order_added]['journal'],
                             order_added
                         ]

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -471,6 +471,32 @@ def get_clans(
     return clans
 
 
+def get_clan_literature(pfam_clan_path: str) -> dict:
+    """Get clan authors and literature data from Pfam-C file
+
+    :param pfam_clan_path: path to Pfam-C release file.
+    """
+    clans = {}
+    try:
+        with gzip.open(pfam_clan_path, 'rt') as fh:
+            for _line in fh:
+                try:
+                    line = _line.decode('utf-8')
+                except UnicodeDecodeError:
+                    logger.error(
+                        "UnicodeDecodeError encountered on PFAM-C line %s. Skipping line.",
+                        line_count
+                    )
+                    continue
+    except FileNotFoundError:
+        logger.error(
+            (
+                "Could not parse Pfam-C (clan) file at %s\n"
+                "Not retrieving clan data"
+            ), pfam_clan_path
+        )
+    return clans
+
 def iter_protenn_matches(file: str):
     """Iterate ProtENN matches from the Pfam-N domain calls TSV file
     """
@@ -554,6 +580,7 @@ def persist_extra_pfam_data(
         pfam_path=db_props["seed"],
         persist_pfam=True,
     )
+    clans = get_clan_literature(db_props['clan'])
 
     logger.info("Persisting data for %s signatures", len(signatures))
 

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -2,8 +2,6 @@ import gzip
 import os
 import re
 
-import MySQLdb
-import MySQLdb.cursors
 import oracledb
 
 from .common import Clan, Method

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -611,3 +611,5 @@ def persist_extra_pfam_data(
                 wiki_query,
                 [pfam_acc, signatures[pfam_acc]["wiki"]]
             )
+    
+    con.close()

--- a/pyinterprod/interpro/signature.py
+++ b/pyinterprod/interpro/signature.py
@@ -70,7 +70,7 @@ def add_staging(uri: str, update: list[tuple[Database, dict[str, str]]]):
             if db.identifier == 'H':
                 # Pfam
                 signatures = contrib.pfam.get_signatures(
-                    db_props["signatures"]
+                    db_props["seed"]
                 )
             elif db.identifier == 'J':
                 # CDD


### PR DESCRIPTION
Add Pfam file parsers, facilitating severance from the Pfam MySQL db.
[JIRA](https://www.ebi.ac.uk/panda/jira/browse/IBU-10833)

Data is retrieved from Pfam files (requiring changes to the `members.config` file):
* `Pfam-A.seed`
* `Pfam-A-full`
* `Pfam-C`
* `Pfam-A.fasta`

The output of the original `get_signatures()` and `get_clans()` functions in the `pfam` module have not been changed.