### PR TITLE
Remove pfam fasta file dependency

### DIFF
--- a/pyinterprod/interpro/clan.py
+++ b/pyinterprod/interpro/clan.py
@@ -619,7 +619,6 @@ def update_hmm_clans(uri: str, database: Database, hmmdb: str, **kwargs):
     logger.info("loading new clans")
     if database.name.lower() == "pfam":
         clans = contrib.pfam.get_clans(kwargs["clans"],
-                                       kwargs["fasta"],
                                        kwargs["full"])
 
         def getsubdir(x): return x[:5]

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -343,8 +343,9 @@ def get_clans(pfam_c: str, pfama_full: str) -> list[Clan]:
         members = []
         for member in entry.features.get("MB", []):
             member = member.rstrip(";")
-            if (num_full.get(member, 0) > total):
-                total = num_full.get(member, 0)
+            num_seqs = num_full.get(member, 0)
+            if num_seqs > total:
+                total = num_seqs
             members.append(member)
 
         clans.append(Clan(accession, name, description))


### PR DESCRIPTION
Pfam-A.fasta was used for for the size of each node in the clan graph viewer.
That has new been replaced with Pfam-A.full, where each node is the fraction of the family size (in terms of sequences in the full alignment).