### PR TITLE
Replace refs on clan CC lines

### DIFF
--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -123,7 +123,8 @@ def _expand_range(s: str) -> list[int]:
             # range of reference numbers, e.g. 1-4
             low, high = map(int, values)
             r += list(range(low, high + 1))
-    return(r)
+
+    return r
 
 
 class StockholdMSA:

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -406,8 +406,6 @@ def persist_pfam_c(uri: str, pfam_c: str):
         for author in entry.features["AU"]:
             authors += [e.strip() for e in author.split(",")]
 
-        comment = entry.features.get("CC")
-
         rn2pmid = {}
         references = []
         for i, ref_dict in enumerate(entry.features.get("RN", [])):
@@ -424,7 +422,10 @@ def persist_pfam_c(uri: str, pfam_c: str):
                 ),
                 "journal": " ".join(ref_dict["RL"])
             })
-        abstract = _repl_references(accession, comment, rn2pmid)
+
+        comment = entry.features.get("CC")
+        if comment:
+            comment = _repl_references(accession, comment, rn2pmid)
 
         cur.execute(
             """
@@ -435,7 +436,7 @@ def persist_pfam_c(uri: str, pfam_c: str):
                 accession,
                 name,
                 description,
-                abstract,
+                comment,
                 json.dumps(authors),
                 json.dumps(references)
             ]

--- a/pyinterprod/interpro/contrib/pfam.py
+++ b/pyinterprod/interpro/contrib/pfam.py
@@ -98,8 +98,7 @@ def get_signatures(pfam_seed_file: str) -> list[Method]:
 def _repl_references(acc: str, text: str, references: dict[int, int]):
     def _repl(match: re.Match) -> str:
         refs = []
-
-        for ref_num in map(int, map(str.strip, _expand_range(match.group(1)).split(','))):
+        for ref_num in _expand_range(match.group(1)):
             try:
                 pmid = references[ref_num]
             except KeyError:
@@ -113,15 +112,18 @@ def _repl_references(acc: str, text: str, references: dict[int, int]):
     return re.sub(r"\[([\d\s,-]+)]", _repl, text)
 
 
-def _expand_range(s):
+def _expand_range(s: str) -> list[int]:
     r = []
     for i in s.split(','):
-        if '-' not in i:
+        values = i.split("-")
+        if len(values) == 1:
+            # single reference number
             r.append(int(i))
         else:
-            l,h = map(int, i.split('-'))
-            r+= range(l,h+1)
-    return f"{','.join(str(item) for item in r)}"
+            # range of reference numbers, e.g. 1-4
+            low, high = map(int, values)
+            r += list(range(low, high + 1))
+    return(r)
 
 
 class StockholdMSA:


### PR DESCRIPTION
references on clan comments now get a reference replacement just like the pfam comments, so [1,2] becomes something like [PMID:111,PMID:222].

References in the form [1-3] were ignored, this also fixes that so they become something like [PMID:111,PMID:222,PMID:333]