### PR TITLE
Import pirsr into ippro

### DIFF
--- a/pyinterprod/interpro/iprscan.py
+++ b/pyinterprod/interpro/iprscan.py
@@ -129,7 +129,7 @@ MATCH_PARTITIONS = {
             'ANALYSIS_ID', 'UPI', 'METHOD_AC', 'SUBSTR(RELNO_MAJOR', '1', '4)',
             'SUBSTR(RELNO_MAJOR', '6', '7)',
             'SEQ_START', 'SEQ_END', 'HMM_START', 'HMM_END', 'HMM_LENGTH',
-            'NULL', 'SCORE', 'SEQSCORE', 'EVALUE', 'SEQEVALUE',
+            'HMM_BOUNDS', 'SCORE', 'SEQSCORE', 'EVALUE', 'SEQEVALUE',
             'ENV_START', 'ENV_END', 'MODEL_AC', 'NULL', 'FRAGMENTS'
         ],
         "partition": "PIRSR"

--- a/pyinterprod/interpro/iprscan.py
+++ b/pyinterprod/interpro/iprscan.py
@@ -124,6 +124,16 @@ MATCH_PARTITIONS = {
         ],
         "partition": "PIRSF"
     },
+    "PIRSR": {
+        "columns": [
+            'ANALYSIS_ID', 'UPI', 'METHOD_AC', 'SUBSTR(RELNO_MAJOR', '1', '4)',
+            'SUBSTR(RELNO_MAJOR', '6', '7)',
+            'SEQ_START', 'SEQ_END', 'HMM_START', 'HMM_END', 'HMM_LENGTH',
+            'SCORE', 'SEQSCORE', 'EVALUE', 'SEQEVALUE',
+            'ENV_START', 'ENV_END', 'MODEL_AC', 'NULL', 'FRAGMENTS'
+        ],
+        "partition": "PIRSR"
+    },
     "PRINTS": {
         "columns": [
             'ANALYSIS_ID', 'UPI', 'METHOD_AC', 'RELNO_MAJOR', 'RELNO_MINOR',

--- a/pyinterprod/interpro/iprscan.py
+++ b/pyinterprod/interpro/iprscan.py
@@ -129,7 +129,7 @@ MATCH_PARTITIONS = {
             'ANALYSIS_ID', 'UPI', 'METHOD_AC', 'SUBSTR(RELNO_MAJOR', '1', '4)',
             'SUBSTR(RELNO_MAJOR', '6', '7)',
             'SEQ_START', 'SEQ_END', 'HMM_START', 'HMM_END', 'HMM_LENGTH',
-            'SCORE', 'SEQSCORE', 'EVALUE', 'SEQEVALUE',
+            'NULL', 'SCORE', 'SEQSCORE', 'EVALUE', 'SEQEVALUE',
             'ENV_START', 'ENV_END', 'MODEL_AC', 'NULL', 'FRAGMENTS'
         ],
         "partition": "PIRSR"


### PR DESCRIPTION
* Tested on `IPDEV`.
* New partitions for PIRSR are available on IPPRO and IPDEV using `IPRSCAN_SIG_LIB_REL_ID` 131
* Tested by calling the `import_matches_or_sites()` function directly:
```python
from pyinterprod.interpro.iprscan import import_matches_or_sites
from pyinterprod.interpro.database import Database
from datetime import datetime

URI = "-----"
DB = Database(
    identifier="",
    name="PIRSR",
    version="",
    date=datetime.now(),
    analysis_id=131,
    has_site_matches=False,
    is_member_db=False,
    is_feature_db=False
)

import_matches_or_sites(
    uri=URI,
    data_type="matches",
    databases=[DB]
)
```
* Imported data can be retrieved in IPDEV:
```sql
SELECT *
FROM IPRSCAN.MV_IPRSCAN PARTITION (PIRSR);
```